### PR TITLE
Add warp migration

### DIFF
--- a/src/main/java/io/github/essentialsx/cmiimporter/CMIImporter.java
+++ b/src/main/java/io/github/essentialsx/cmiimporter/CMIImporter.java
@@ -39,6 +39,7 @@ public final class CMIImporter extends JavaPlugin implements Listener {
             .put("users", Migrations::migrateUsers)
             .put("homes", Migrations::migrateHomes)
             .put("nicknames", Migrations::migrateNicknames)
+            .put("warps", Migrations::migrateWarps)
             .build();
 
     @Override

--- a/src/main/java/io/github/essentialsx/cmiimporter/Util.java
+++ b/src/main/java/io/github/essentialsx/cmiimporter/Util.java
@@ -38,14 +38,14 @@ public class Util {
         return result;
     }
 
-    public static Location parseLocation(String input) {
-        String[] split = input.split(":");
+    public static Location parseLocation(String input, String separator, boolean reverseYawPitch) {
+        String[] split = input.split(separator);
         World world = Bukkit.getWorld(split[0]);
         double x = Double.parseDouble(split[1]);
         double y = Double.parseDouble(split[2]);
         double z = Double.parseDouble(split[3]);
-        float yaw = Float.parseFloat(split[5]);
-        float pitch = Float.parseFloat(split[4]);
+        float yaw = Float.parseFloat((reverseYawPitch ? split[5] : split[4]));
+        float pitch = Float.parseFloat((reverseYawPitch ? split[4] : split[5]));
         return new Location(world, x, y, z, yaw, pitch);
     }
 


### PR DESCRIPTION
A possible implementation for importing CMI warps.

For some reason the locations are separated with `;` instead of `:` and the yaw and pitch are the right way around in the warps data, so I had to modify the `Util#parseLocation` method a little.