### PR TITLE
Add mail migration

### DIFF
--- a/src/main/java/io/github/essentialsx/cmiimporter/Migrations.java
+++ b/src/main/java/io/github/essentialsx/cmiimporter/Migrations.java
@@ -40,6 +40,8 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.logging.Logger;
 
+import static com.earth2me.essentials.I18n.tl;
+
 public class Migrations {
 
     private static final Logger logger = Logger.getLogger("EssentialsX-CMI-Importer");
@@ -62,6 +64,7 @@ public class Migrations {
         migrateEconomy(ess);
         migrateLastLogin(ess);
         migrateLastLogout(ess);
+        migrateMail(ess);
     }
 
     static void migrateUsers(Essentials ess) {
@@ -196,6 +199,26 @@ public class Migrations {
                     user.setLastLogout(lastLogoffTime);
                 } catch (Exception ex) {
                     logger.warning("Could not set the last logoff time for: " + user.getLastAccountName());
+                }
+            }
+        } catch (SQLException ex) {
+            ex.printStackTrace();
+        }
+    }
+
+    static void migrateMail(Essentials ess) {
+        try {
+            List<DbRow> results = DB.getResults("SELECT player_uuid, Mail FROM " + table("users") + " WHERE player_uuid NOT NULL AND Mail NOT NULL");
+            for (DbRow row : results) {
+                UUID uuid = UUID.fromString(row.get("player_uuid"));
+                User user = ess.getUser(uuid);
+                List<List<String>> mails = Util.parseLists(row.getString("Mail"), ";", ":");
+                for (List<String> mail : mails) {
+                    String sender = mail.get(0);
+                    // CMI replaces ";" with "T7C" and ":" with "T8C" when storing message contents
+                    String content = mail.get(2).replace("T7C", ";").replace("T8C", ":");
+                    String mailFormat = tl("mailFormat", sender, content);
+                    user.addMail(tl("mailMessage", mailFormat));
                 }
             }
         } catch (SQLException ex) {

--- a/src/main/java/io/github/essentialsx/cmiimporter/Util.java
+++ b/src/main/java/io/github/essentialsx/cmiimporter/Util.java
@@ -22,7 +22,10 @@ import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.World;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class Util {
@@ -36,6 +39,14 @@ public class Util {
         }
 
         return result;
+    }
+
+    public static List<List<String>> parseLists(String input, String listSeparator, String elementSeparator) {
+        List<List<String>> parent = new ArrayList<>();
+        for (String list : input.split(listSeparator)) {
+            parent.add(Arrays.asList(list.split(elementSeparator)));
+        }
+        return parent;
     }
 
     public static Location parseLocation(String input, String separator, boolean reverseYawPitch) {


### PR DESCRIPTION
An implementation of mail migration, confirmed to be working on valid mail data. `Util.parseLists` method might be questionable (?). Currently reads but ignores timestamps.